### PR TITLE
Fixed navbar and h1 text error in repo page| Fixed issue #25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -454,7 +454,6 @@
       "version": "11.13.3",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
       "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.12.0",
@@ -497,7 +496,6 @@
       "version": "11.13.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
       "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.12.0",
@@ -1232,7 +1230,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.1.4.tgz",
       "integrity": "sha512-mIVdjzDYU4U/XYzf8pPEz3zDZFS4Wbyr0cjfgeGiT/s60EvtEresXXQy8XUA0bpJDJjgic1Hl5AIRcqWDyi2eg==",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",
         "@mui/core-downloads-tracker": "^6.1.4",

--- a/src/pages/Repopage.jsx
+++ b/src/pages/Repopage.jsx
@@ -9,9 +9,8 @@ import Navbar from './Navbar';
 const Repopage = () => {
   return (
     <div>
-      <Navbar />
+      <Navbar /><br></br><br />
       <div className="flex flex-col items-center justify-center h-screen p-4">
-        <h1 className="text-4xl font-bold mb-10 uppercase">REPOSITORIES</h1>
         <div className="flex space-x-4">
           <div className="flex flex-col items-center justify-center min-h-screen p-4">
             <h1 className="text-3xl md:text-4xl font-bold mb-10 uppercase text-center">


### PR DESCRIPTION
The navbar in repo page had extra text written as Repositories Fixed that issue.

Issue:
![Screenshot 2024-10-20 125421](https://github.com/user-attachments/assets/63005da5-ec05-4b87-9a51-992392e402a2)

Updated repo page:
![Screenshot 2024-10-20 125512](https://github.com/user-attachments/assets/36d8f41b-9203-4ba5-9839-eae9e6688f98)
